### PR TITLE
Update imgboxdwl

### DIFF
--- a/imgboxdwl
+++ b/imgboxdwl
@@ -80,9 +80,10 @@ if [[ ! $i -ge $(number_of_images_in_the_gallery "${gallery_url}") ]]; then
 
 	printf -v link "https://imgbox.com/%s" $(extract_name "${url}")
 	temp=$(curl -s "${link}" | grep -E -o 'https?.*download=true')
+        temp2="$(echo ${temp%%\?*})";extension="${temp2##*.}"
 
-#	curl -O -# $(seq -w "$i"|grep "$i")_"${temp%%\?*}"
-        curl -o $(printf "%03d\n" $i)_$(extract_name "${url}").jpg "${temp%%\?*}"
+        curl -o $(printf "%03d\n" $i)_$(extract_name "${url}")."$extension" -O -# "${temp%%\?*}"
+
 
 fi
 

--- a/imgboxdwl
+++ b/imgboxdwl
@@ -73,12 +73,20 @@ mkdir -p "${gallery_name}" && cd "${gallery_name}"
 
 printf "\\n\\nAbout to save %d images to folder %s/\\n\\n" $(number_of_images_in_the_gallery "${gallery_url}") "${gallery_name}"
 
+i=001;
 for url in $(curl -s "${gallery_url}" | grep -E -o 'thumbs[0-9]+.*"' | tr -d '"'); do
+
+if [[ ! $i -ge $(number_of_images_in_the_gallery "${gallery_url}") ]]; then
 
 	printf -v link "https://imgbox.com/%s" $(extract_name "${url}")
 	temp=$(curl -s "${link}" | grep -E -o 'https?.*download=true')
 
-	curl -O -# ${temp%%\?*}
+#	curl -O -# $(seq -w "$i"|grep "$i")_"${temp%%\?*}"
+        curl -o $(printf "%03d\n" $i)_$(extract_name "${url}").jpg "${temp%%\?*}"
+
+fi
+
+i=$((i+1))
 done
 
 printf "\\n\\n%s images were saved to folder %s/\\n\\n" $(find . -type f | wc -l) "${gallery_name}"


### PR DESCRIPTION
Prefix images by number so the image order is the same as in the web gallery. My code is amateur, likely you will improve, yet it seems to be working. Test: sh imgboxdl https://imgbox.com/g/sZ6kIg3f1X

btw: a cosmetic issue (possibly not related to this patch) is that in case the image does not exist on server (yes it happens, thumbnail exist, but not full file), it still downloads the file which then contains:

```
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```
